### PR TITLE
Use parse section

### DIFF
--- a/fluent.conf
+++ b/fluent.conf
@@ -2,11 +2,13 @@
   @type tail
   path "#{ENV['APPLICATION_LOG_DIR']}/*.log"
   pos_file /var/tmp/application.log.pos
-  format "#{ENV['LOG_FORMAT'] || 'json'}"
-  time_key "#{ENV['TIME_KEY']}"
-  time_format "#{ENV['TIME_FORMAT'] || '%Y-%m-%dT%H:%M:%S%z'}"
-  keep_time_key true
   tag "#{ENV['TAG_PREFIX']}.*"
+  <parse>
+    @type "#{ENV['LOG_FORMAT'] || 'json'}"
+    time_key "#{ENV['TIME_KEY']}"
+    keep_time_key true
+    time_format "#{ENV['TIME_FORMAT'] || '%Y-%m-%dT%H:%M:%S%z'}"
+  </parse>
 </source>
 
 <match **>


### PR DESCRIPTION
ref: https://docs.fluentd.org/input/tail#format

`format` parameter is deprecated.
So it should use parse section.
https://docs.fluentd.org/configuration/parse-section

